### PR TITLE
LiensUtiles.md - changement liens morts archi

### DIFF
--- a/LiensUtiles.md
+++ b/LiensUtiles.md
@@ -30,10 +30,10 @@
 
 ## Archi
 
-* [EN] [debug-pro.com/epita/s1/en](http://debug-pro.com/epita/s1/en) (S1)
-* [FR] [debug-pro.com/epita/s1/fr](http://debug-pro.com/epita/s1/fr) (S1)
-* [EN] [debug-pro.com/epita/s2/en](http://debug-pro.com/epita/s2/en) (S2)
-* [FR] [debug-pro.com/epita/s2/fr](http://debug-pro.com/epita/s2/fr) (S2)
+* [EN] [debug-pro.com/epita/archi/s1/en](http://debug-pro.com/epita/archi/s1/en/) (S1)
+* [FR] [debug-pro.com/epita/s1/fr](http://debug-pro.com/epita/s1/fr) (S1) (lien mort !)
+* [EN] [debug-pro.com/epita/s2/en](http://debug-pro.com/epita/s2/en) (S2) (lien mort !)
+* [FR] [debug-pro.com/epita/s2/fr](http://debug-pro.com/epita/s2/fr) (S2) (lien mort !)
 
 ## Wiki-prog
 


### PR DESCRIPTION
Tous les liens d'archi étaient morts, visiblement seulement la version anglaise du S1 est en ligne à l'heure qu'il est. Donc j'ai remplacé la version anglaise du S1 et j'ai noté "lien mort" à côté des autres